### PR TITLE
Fix for the empty task list message not displaying

### DIFF
--- a/src/main/java/net/reldo/taskstracker/panel/TaskListPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/TaskListPanel.java
@@ -80,12 +80,13 @@ public class TaskListPanel extends JScrollPane
 				.filter(tp -> tp.task.getName().equalsIgnoreCase(task.getName()))
 				.findFirst();
 			panel.ifPresent(TaskPanel::refresh);
-			return;
 		}
-
-		for (TaskPanel taskPanel : taskPanels)
+		else
 		{
-			taskPanel.refresh();
+			for (TaskPanel taskPanel : taskPanels)
+			{
+				taskPanel.refresh();
+			}
 		}
 
 		Optional<TaskPanel> visibleTaskPanel = taskPanels.stream()


### PR DESCRIPTION
The task list would not show the empty list message if it was made empty by updating a single task. This makes the task list panel check if it is empty each time any number of tasks are refreshed.