### PR TITLE
Fix issues #33 and #52

### DIFF
--- a/src/main/java/net/reldo/taskstracker/TasksTrackerConfig.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerConfig.java
@@ -91,12 +91,12 @@ public interface TasksTrackerConfig extends Config
 
 	@ConfigItem(
 		position = 106,
-		keyName = "taskTypeName",
+		keyName = "taskTypeJsonName",
 		name = "Task Type",
 		description = "Configures the task type which is displayed in the panel.",
 		hidden = true
 	)
-	default String taskTypeName()
+	default String taskTypeJsonName()
 	{
 		return "COMBAT";
 	}

--- a/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
@@ -51,6 +51,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.config.RuneScapeProfileType;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -118,8 +119,8 @@ public class TasksTrackerPlugin extends Plugin
 	{
 		try
 		{
-			String taskTypeName = config.taskTypeName();
-			taskService.setTaskType(taskTypeName);
+			String taskTypeJsonName = config.taskTypeJsonName();
+			taskService.setTaskType(taskTypeJsonName);
 		}
 		catch (Exception ex)
 		{
@@ -252,9 +253,15 @@ public class TasksTrackerPlugin extends Plugin
 		}
 	}
 
+	@Subscribe
+	public void onProfileChanged(ProfileChanged profileChanged)
+	{
+		reload();
+	}
+
 	public void refresh()
 	{
-		SwingUtilities.invokeLater(() -> this.pluginPanel.refresh(null));
+		SwingUtilities.invokeLater(() -> pluginPanel.refresh(null));
 	}
 
 	public void reloadTaskType()
@@ -263,8 +270,8 @@ public class TasksTrackerPlugin extends Plugin
 		filterService.clearFilterConfigs();
 		try
 		{
-			String taskTypeName = config.taskTypeName();
-			taskService.setTaskType(taskTypeName);
+			String taskTypeJsonName = config.taskTypeJsonName();
+			taskService.setTaskType(taskTypeJsonName);
 		}
 		catch (Exception ex)
 		{
@@ -272,8 +279,8 @@ public class TasksTrackerPlugin extends Plugin
 		}
 		SwingUtilities.invokeLater(() ->
 		{
-			this.pluginPanel.redraw();
-			this.pluginPanel.refresh(null);
+			pluginPanel.redraw();
+			pluginPanel.refresh(null);
 		});
 	}
 
@@ -312,7 +319,7 @@ public class TasksTrackerPlugin extends Plugin
 			return;
 		}
 
-		if (!reldoImport.taskTypeName.equalsIgnoreCase(config.taskTypeName()))
+		if (!reldoImport.taskTypeName.equalsIgnoreCase(config.taskTypeJsonName()))
 		{
 			this.showMessageBox("Import Tasks Error", String.format("Wrong task type. Select the %s task type to import this data.", reldoImport.taskTypeName), JOptionPane.ERROR_MESSAGE, false);
 			return;

--- a/src/main/java/net/reldo/taskstracker/data/task/TaskService.java
+++ b/src/main/java/net/reldo/taskstracker/data/task/TaskService.java
@@ -74,7 +74,7 @@ public class TaskService
 		{
 			tasks.clear();
 			currentTaskType = newTaskType;
-			configManager.setConfiguration(TasksTrackerPlugin.CONFIG_GROUP_NAME, "taskTypeName", newTaskType.getTaskJsonName());
+			configManager.setConfiguration(TasksTrackerPlugin.CONFIG_GROUP_NAME, "taskTypeJsonName", newTaskType.getTaskJsonName());
 
             // Complete creation of any GLOBAL value type filterConfigs
 			for (FilterConfig filterConfig : currentTaskType.getFilters())

--- a/src/main/java/net/reldo/taskstracker/panel/LoggedInPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/LoggedInPanel.java
@@ -83,6 +83,22 @@ public class LoggedInPanel extends JPanel
 
 	public void redraw()
 	{
+		// taskTypeDropdown may become de-synced after profile change
+		String selectedTaskTypeJsonName = taskTypeDropdown.getItemAt(taskTypeDropdown.getSelectedIndex()).getValue().getTaskJsonName();
+		if(!selectedTaskTypeJsonName.equals(config.taskTypeJsonName()))
+		{
+			log.info("Task type dropdown de-synced, attempting to find current task type");
+			for(int i = 0; i < taskTypeDropdown.getItemCount(); i++)
+			{
+				ComboItem<TaskType> item = taskTypeDropdown.getItemAt(i);
+				if(item.getValue().getTaskJsonName().equals(config.taskTypeJsonName()))
+				{
+					log.info("Current task type found, setting selected task type");
+					taskTypeDropdown.setSelectedIndex(i);
+					break;
+				}
+			}
+		}
 		subFilterPanel.redraw();
 		sortPanel.redraw();
 		updateCollapseButtonText();

--- a/src/main/java/net/reldo/taskstracker/panel/TaskListPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/TaskListPanel.java
@@ -13,9 +13,11 @@ import javax.swing.border.EmptyBorder;
 import lombok.extern.slf4j.Slf4j;
 import net.reldo.taskstracker.TasksTrackerPlugin;
 import net.reldo.taskstracker.config.ConfigValues;
+import net.reldo.taskstracker.data.jsondatastore.types.TaskDefinitionSkill;
 import net.reldo.taskstracker.data.task.TaskFromStruct;
 import net.reldo.taskstracker.data.task.TaskService;
 import net.reldo.taskstracker.panel.components.FixedWidthPanel;
+import net.runelite.api.Skill;
 import net.runelite.client.ui.FontManager;
 
 @Slf4j
@@ -82,6 +84,29 @@ public class TaskListPanel extends JScrollPane
 		{
 			log.error("Task list panel refresh failed - not event dispatch thread.");
 		}
+	}
+
+	public void refreshTaskPanelsWithSkill(Skill skill)
+	{
+		// Refresh all task panels for tasks with 'skill' or
+		// 'SKILLS' (any skill) or 'TOTAL LEVEL' as a requirement.
+		taskPanels.stream()
+				.filter(tp ->
+				{
+					List<TaskDefinitionSkill> skillsList = tp.task.getTaskDefinition().getSkills();
+					if(skillsList == null || skillsList.isEmpty())
+					{
+						return false;
+					}
+
+					return skillsList.stream()
+						.map(TaskDefinitionSkill::getSkill)
+						.anyMatch(s ->  s.equalsIgnoreCase(skill.getName()) ||
+                                        s.equalsIgnoreCase("SKILLS") ||
+                                        s.equalsIgnoreCase("TOTAL LEVEL")
+						);
+				})
+				.forEach(TaskPanel::refresh);
 	}
 
 	private class TaskListListPanel extends FixedWidthPanel

--- a/src/main/java/net/reldo/taskstracker/panel/TasksTrackerPluginPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/TasksTrackerPluginPanel.java
@@ -66,24 +66,29 @@ public class TasksTrackerPluginPanel extends PluginPanel
 
 	public void setLoggedIn(boolean loggedIn)
 	{
-		assert SwingUtilities.isEventDispatchThread();
-
-		if (loggedIn != this.loggedIn)
+		if(SwingUtilities.isEventDispatchThread())
 		{
-			if (loggedIn)
-			{
-				loggedOutPanel.setVisible(false);
-				loggedInPanel.setVisible(true);
-			}
-			else
-			{
-				loggedInPanel.setVisible(false);
-				loggedOutPanel.setVisible(true);
-			}
+            if (loggedIn != this.loggedIn)
+            {
+                if (loggedIn)
+                {
+                    loggedOutPanel.setVisible(false);
+                    loggedInPanel.setVisible(true);
+                }
+                else
+                {
+                    loggedInPanel.setVisible(false);
+                    loggedOutPanel.setVisible(true);
+                }
 
-			validate();
-			repaint();
+                validate();
+                repaint();
+            }
+            this.loggedIn = loggedIn;
 		}
-		this.loggedIn = loggedIn;
+		else
+		{
+			log.error("Failed to update loggedIn state - not event dispatch thread.");
+		}
 	}
 }

--- a/src/main/java/net/reldo/taskstracker/panel/filters/DynamicDropdownFilterPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/filters/DynamicDropdownFilterPanel.java
@@ -70,18 +70,23 @@ public class DynamicDropdownFilterPanel extends FilterPanel
 
 	public void redraw()
 	{
-		assert SwingUtilities.isEventDispatchThread();
+		if(SwingUtilities.isEventDispatchThread())
+		{
+			removeAll();
 
-		removeAll();
+			dropdown = makeDropdownPanel();
 
-		dropdown = makeDropdownPanel();
+			add(makeLabel());
+			add(dropdown);
 
-		add(makeLabel());
-		add(dropdown);
+			updateFilterConfig();
 
-		updateFilterConfig();
-
-		validate();
-		repaint();
+			validate();
+			repaint();
+		}
+		else
+		{
+			log.error("Dropdown filter panel redraw failed - not event dispatch thread.");
+		}
 	}
 }

--- a/src/main/java/net/reldo/taskstracker/panel/filters/FilterButtonPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/filters/FilterButtonPanel.java
@@ -19,12 +19,14 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.basic.BasicBorders;
 import javax.swing.plaf.basic.BasicButtonUI;
+import lombok.extern.slf4j.Slf4j;
 import net.reldo.taskstracker.TasksTrackerPlugin;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.SwingUtil;
 
+@Slf4j
 public abstract class FilterButtonPanel extends FilterPanel
 {
     protected final TasksTrackerPlugin plugin;
@@ -194,23 +196,28 @@ public abstract class FilterButtonPanel extends FilterPanel
 
     public void redraw()
     {
-        assert SwingUtilities.isEventDispatchThread();
+        if(SwingUtilities.isEventDispatchThread())
+        {
+            buttons.clear();
+            removeAll();
 
-        buttons.clear();
-        removeAll();
+            collapseBtn = makeCollapseButton();
+            buttonPanel = makeButtonPanel();
 
-        collapseBtn = makeCollapseButton();
-        buttonPanel = makeButtonPanel();
+            add(collapseBtn, BorderLayout.NORTH);
+            add(buttonPanel, BorderLayout.CENTER);
+            add(allOrNoneButtons(), BorderLayout.SOUTH);
+            updateFilterText();
+            updateCollapseButtonText();
 
-        add(collapseBtn, BorderLayout.NORTH);
-        add(buttonPanel, BorderLayout.CENTER);
-        add(allOrNoneButtons(), BorderLayout.SOUTH);
-        updateFilterText();
-        updateCollapseButtonText();
+            collapseBtn.setVisible(plugin.getConfig().filterPanelCollapsible());
 
-        collapseBtn.setVisible(plugin.getConfig().filterPanelCollapsible());
-
-        validate();
-        repaint();
+            validate();
+            repaint();
+        }
+        else
+        {
+            log.error("Filter button panel redraw failed - not event dispatch thread.");
+        }
     }
 }


### PR DESCRIPTION
### Fix refresh task panels on level up (fixes #33)
- Move player skill tracking to onStatChanged event
- Only refresh panels for tasks that require the levelled skill


### Support profile swapping (fixes #52)
- Change thread assertion to if statements
- Reload plugin on profile change event
- Fix taskTypeDropdown de-sync after profile swap
- Clarify task type name vs json name