### PR TITLE
fix: avoid hanging when task loading fails

### DIFF
--- a/src/main/java/net/reldo/taskstracker/data/task/TaskType.java
+++ b/src/main/java/net/reldo/taskstracker/data/task/TaskType.java
@@ -40,26 +40,30 @@ public class TaskType
 	{
 		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		clientThread.invokeLater(() -> {
-			getButtonFiltersSpriteIds().forEach((spriteId) -> {
-				BufferedImage spriteImage = spriteManager.getSprite(spriteId, 0);
-				spritesById.put(spriteId, spriteImage);
-			});
-			_taskTypeDefinition.getTierSpriteIdMap().forEach((idKey, spriteId) -> {
-				Integer tierId = Integer.parseInt(idKey);
-				BufferedImage spriteImage = spriteManager.getSprite(spriteId, 0);
-				tierSprites.put(tierId, spriteImage);
-			});
-			if (_taskTypeDefinition.getIntEnumMap().containsKey("tierPoints"))
-			{
-				int enumId = _taskTypeDefinition.getIntEnumMap().get("tierPoints");
-				EnumComposition enumComposition = client.getEnum(enumId);
-				int[] keys = enumComposition.getKeys();
-				for (int key : keys)
+			try {
+				getButtonFiltersSpriteIds().forEach((spriteId) -> {
+					BufferedImage spriteImage = spriteManager.getSprite(spriteId, 0);
+					spritesById.put(spriteId, spriteImage);
+				});
+				_taskTypeDefinition.getTierSpriteIdMap().forEach((idKey, spriteId) -> {
+					Integer tierId = Integer.parseInt(idKey);
+					BufferedImage spriteImage = spriteManager.getSprite(spriteId, 0);
+					tierSprites.put(tierId, spriteImage);
+				});
+				if (_taskTypeDefinition.getIntEnumMap().containsKey("tierPoints"))
 				{
-					tierPoints.put(key, enumComposition.getIntValue(key));
+					int enumId = _taskTypeDefinition.getIntEnumMap().get("tierPoints");
+					EnumComposition enumComposition = client.getEnum(enumId);
+					int[] keys = enumComposition.getKeys();
+					for (int key : keys)
+					{
+						tierPoints.put(key, enumComposition.getIntValue(key));
+					}
 				}
+				future.complete(true);
+			} catch (Exception e) {
+				future.completeExceptionally(e);
 			}
-			future.complete(true);
 		});
 
 		return future;


### PR DESCRIPTION
Avoids freezing the runelite client when the plugin loads

```
2024-11-30 19:52:31 EST [Client] ERROR n.r.client.callback.ClientThread - Exception in invoke
wt: 
	at hm.aw(hm.java:16788)
	at fp.aw(fp.java:30)
	at client.vs(client.java:22589)
	at client.getEnum(client.java:14129)
	at net.reldo.taskstracker.data.task.TaskType.lambda$loadTaskTypeDataAsync$2(TaskType.java:55)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:80)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:226)
	at client.ke(client.java:19485)
	at client.bu(client.java)
	at bo.am(bo.java:391)
	at bo.iz(bo.java)
	at bo.run(bo.java:9213)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: null
	at pi.lq(pi.java)
	at fp.aw(fp.java:31)
	... 13 common frames omitted
```

(but the blocking future usage ought to be refactored away in a separate PR)

(also the bad enum id can be diagnosed later)
