### PR TITLE
Fix hanging by checking on profile change to see if the plugin exists

### DIFF
--- a/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
@@ -309,7 +310,11 @@ public class TasksTrackerPlugin extends Plugin
 	@Subscribe
 	public void onProfileChanged(ProfileChanged profileChanged)
 	{
-		reloadTaskType();
+		final Optional<Plugin> taskTrackerPlugin = pluginManager.getPlugins().stream().filter(p -> p.getName().equals("Tasks Tracker")).findFirst();
+		if (taskTrackerPlugin.isPresent() && pluginManager.isPluginEnabled(taskTrackerPlugin.get()))
+		{
+			reloadTaskType();
+		}
 	}
 
 	public void refresh()


### PR DESCRIPTION
Fixes #80 

Steps to reproduce error:
Copy your main game profile (disable the plugin on your main profile)
enable it on your copy profile
set the copy profile as default for league world
switch back to main profile
click log in and it hangs.

OR if you already have a league profile

enable the plugin
click log in

This seems to fix both going to and going from a league profile.