### PR TITLE
Remove clientThread.invokeLater call from start-up

### DIFF
--- a/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
@@ -466,7 +466,7 @@ public class TasksTrackerPlugin extends Plugin
 	private CompletableFuture<Boolean> processTaskStatus(TaskFromStruct task)
 	{
 		CompletableFuture<Boolean> future = new CompletableFuture<>();
-		clientThread.invokeLater(() -> {
+		clientThread.invoke(() -> {
 			int taskId =  task.getIntParam("id");
 			int varbitIndex = taskId / 32;
 			int bitIndex = taskId % 32;


### PR DESCRIPTION
Replaces another instance of `clientThread::invokeLater` with `invoke` to prevent plugin hang during profile auto switch.