### PR TITLE
Improve task refresh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.14.9'
 }
 
-group = '${group_id}'
-version = '${version}'
+group = 'net.reldo'
+version = '1.0-SNAPSHOT'
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
@@ -482,7 +482,6 @@ public class TasksTrackerPlugin extends Plugin
 					task.setTracked(false);
 				}
 				log.debug("process taskFromStruct {} ({}) {}", task.getStringParam("name"), task.getIntParam("id"), isTaskCompleted);
-				SwingUtilities.invokeLater(() -> pluginPanel.refresh(task));
 				future.complete(isTaskCompleted);
 			}
 			catch (Exception ex)
@@ -515,7 +514,19 @@ public class TasksTrackerPlugin extends Plugin
 		}
 
 		CompletableFuture<Void> allTasksFuture = CompletableFuture.allOf(taskFutures.toArray(new CompletableFuture[0]));
-		return allTasksFuture.thenApply(v -> true);
+		return allTasksFuture
+			.thenRun(() -> {
+				if (varpId != null)
+				{
+					for (TaskFromStruct task : tasks)
+					{
+						SwingUtilities.invokeLater(() -> pluginPanel.refresh(task));
+					}
+				} else {
+					SwingUtilities.invokeLater(() -> pluginPanel.refresh(null));
+				}
+			})
+			.thenApply(v -> true);
 	}
 
 	private String getCurrentTaskTypeExportJson()

--- a/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
+++ b/src/main/java/net/reldo/taskstracker/TasksTrackerPlugin.java
@@ -156,6 +156,7 @@ public class TasksTrackerPlugin extends Plugin
 	@Override
 	protected void shutDown()
 	{
+		pluginPanel.hideLoggedInPanel();
 		pluginPanel = null;
 		taskService.clearTaskTypes();
 		clientToolbar.removeNavigation(navButton);

--- a/src/main/java/net/reldo/taskstracker/panel/TasksTrackerPluginPanel.java
+++ b/src/main/java/net/reldo/taskstracker/panel/TasksTrackerPluginPanel.java
@@ -21,7 +21,7 @@ public class TasksTrackerPluginPanel extends PluginPanel
 
 	public TaskListPanel taskListPanel;
 
-	private boolean loggedIn = false;
+	private boolean loggedInPanelVisible = false;
 	private TaskService taskService;
 
 	public TasksTrackerPluginPanel(TasksTrackerPlugin plugin, TasksTrackerConfig config, SpriteManager spriteManager, TaskService taskService)
@@ -50,7 +50,7 @@ public class TasksTrackerPluginPanel extends PluginPanel
 
 	public void redraw()
 	{
-		if (loggedIn)
+		if (loggedInPanelVisible)
 		{
 			loggedInPanel.redraw();
 		}
@@ -58,7 +58,7 @@ public class TasksTrackerPluginPanel extends PluginPanel
 
 	public void refresh(TaskFromStruct task)
 	{
-		if (loggedIn)
+		if (loggedInPanelVisible)
 		{
 			loggedInPanel.refresh(task);
 		}
@@ -68,27 +68,46 @@ public class TasksTrackerPluginPanel extends PluginPanel
 	{
 		if(SwingUtilities.isEventDispatchThread())
 		{
-            if (loggedIn != this.loggedIn)
-            {
-                if (loggedIn)
-                {
-                    loggedOutPanel.setVisible(false);
-                    loggedInPanel.setVisible(true);
-                }
-                else
-                {
-                    loggedInPanel.setVisible(false);
-                    loggedOutPanel.setVisible(true);
-                }
-
-                validate();
-                repaint();
-            }
-            this.loggedIn = loggedIn;
+			updateVisiblePanel(loggedIn);
 		}
 		else
 		{
 			log.error("Failed to update loggedIn state - not event dispatch thread.");
 		}
 	}
+
+	public void hideLoggedInPanel()
+	{
+		if(SwingUtilities.isEventDispatchThread())
+		{
+			updateVisiblePanel(false);
+		}
+		else
+		{
+			log.error("Failed to update logged in panel visibility - not event dispatch thread.");
+		}
+	}
+
+	private void updateVisiblePanel(boolean loggedInPanelVisible)
+	{
+		if (loggedInPanelVisible != this.loggedInPanelVisible)
+		{
+			if (loggedInPanelVisible)
+			{
+				loggedOutPanel.setVisible(false);
+				loggedInPanel.setVisible(true);
+			}
+			else
+			{
+				loggedInPanel.setVisible(false);
+				loggedOutPanel.setVisible(true);
+			}
+
+			validate();
+			repaint();
+		}
+		this.loggedInPanelVisible = loggedInPanelVisible;
+	}
+
+
 }


### PR DESCRIPTION
### My testing setup:
I set up a hacky runelite core branch where I can test our plugin as if it were on the hub. Not sure if it's the correct or accepted approach but it works.

You can find it here if you want to replicate:
[branch](https://github.com/osrs-reldo/runelite/commits/plugin-testing) [commit](https://github.com/osrs-reldo/runelite/commit/159c39f810908a67215cae78f231425904fa9824)

I configured two profiles:
- League profile with plugin
- Non-league profile without plugin

I swapped worlds with the plugin panel open to force the profile change.

### Before fix:
From Non-league to League => The client hung at the installing plugins. I waited about 15 minutes and it still didn't load.
From League to Non-league => I couldn't test because it hung in the above

### After fix:
From Non-league to League => Small maybe 5 second hang, could just world swap + plugin installs tbh
From League to Non-league => No hang
